### PR TITLE
fix: ensure --shared-secret-file option is parsed correctly

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -186,6 +186,7 @@ fn create_parser() -> Command {
             // .conflicts_with(ARG_NO_AUTHENTICATION)
             // .required_unless_one(&[ARG_NO_AUTHENTICATION, ARG_SHARED_SECRET])
             .env("AUDIOSERVE_SHARED_SECRET_FILE")
+            .value_parser(is_existing_file)
             .help("File containing shared secret, it's slightly safer to read it from file, then provide as command argument")
             )
         .arg(Arg::new(ARG_TRANSCODING_MAX_PARALLEL_PROCESSES)


### PR DESCRIPTION
Because without this I get this nice little panic as a result of trying to cast a `str` to a `PathBuf`:
```
Dec 17 19:57:11 audioserve audioserve[19308]: thread 'main' panicked at 'Mismatch between definition and access of `shared-secret-file`. Could not downcast to TypeId { t: 4399610753556728148 }, need to downcast to TypeId { t: 1304051904763511523 }
Dec 17 19:57:11 audioserve audioserve[19308]: ', ~/.cargo/registry/src/github.com-1285ae84e5963aae/clap-4.0.18/src/parser/error.rs:30:9
Dec 17 19:57:11 audioserve audioserve[19308]: stack backtrace:
Dec 17 19:57:11 audioserve audioserve[19308]:    0: rust_begin_unwind
Dec 17 19:57:11 audioserve audioserve[19308]:              at ./rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/std/src/panicking.rs:575:5
Dec 17 19:57:11 audioserve audioserve[19308]:    1: core::panicking::panic_fmt
Dec 17 19:57:11 audioserve audioserve[19308]:              at ./rustc/69f9c33d71c871fc16ac445211281c6e7a340943/library/core/src/panicking.rs:65:14
Dec 17 19:57:11 audioserve audioserve[19308]:    2: clap::parser::matches::arg_matches::ArgMatches::remove_one
Dec 17 19:57:11 audioserve audioserve[19308]:    3: audioserve::config::cli::parse_args_from
Dec 17 19:57:11 audioserve audioserve[19308]:    4: audioserve::main
```