### PR TITLE
feat: read description from 'comment' tag too

### DIFF
--- a/crates/collection/src/audio_meta.rs
+++ b/crates/collection/src/audio_meta.rs
@@ -304,7 +304,7 @@ mod libavformat {
 
     static INIT_LIBAV: Once = Once::new();
 
-    const DESCRIPTION_KEY: &str = "description";
+    const DESCRIPTION_KEYS: &[&str] = &["description", "comment"];
 
     pub fn init() {
         INIT_LIBAV.call_once(media_info::init)
@@ -358,11 +358,15 @@ mod libavformat {
         }
 
         fn has_description(&self) -> bool {
-            self.media_file.has_meta(DESCRIPTION_KEY)
+            DESCRIPTION_KEYS
+                .iter()
+                .any(|&key| self.media_file.has_meta(key))
         }
 
         fn description(&self) -> Option<String> {
-            self.media_file.meta(DESCRIPTION_KEY)
+            DESCRIPTION_KEYS
+                .iter()
+                .find_map(|&key| self.media_file.meta(key))
         }
     }
 


### PR DESCRIPTION
When encoding to an opus (Ogg) container with ffmpeg, attempts to set the `description` tag result in writing to the `comment` tag instead. I.e. `description` appears to be a write-only alias for the `comment` tag for at least some output formats.

This allows us to still get audio book descriptions from the fallback `comment` tag in those cases. This also applies to the
(decrypted from `aaxc`) `m4b` files coming from Audible.