### PR TITLE
Fix Docker build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# check=error=true
+
 ARG CARGO_ARGS
 ARG CARGO_RELEASE="release"
 
@@ -20,7 +22,7 @@ RUN if [[ -n "$CARGO_RELEASE" ]]; then CARGO_RELEASE="--$CARGO_RELEASE"; fi && \
     cargo build ${CARGO_RELEASE} ${CARGO_ARGS} &&\
     cargo test ${CARGO_RELEASE} --all ${CARGO_ARGS}
 
-FROM node:20-alpine as client
+FROM node:20-alpine AS client
 
 RUN apk add git &&\
     git clone https://github.com/izderadicka/audioserve-web.git /audioserve_client &&\

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,3 +1,5 @@
+# check=error=true
+
 FROM alpine:3.19 AS build
 LABEL maintainer="Ivan <ivan@zderadicka.eu>"
 ENV CARGO_ARGS=""


### PR DESCRIPTION
This PR fixes the Dockerfile so that it no longer displays warnings as seen below.

<img width="568" alt="image" src="https://github.com/user-attachments/assets/d499422d-919b-407b-986c-7a8280887487">

This PR also adds in a check that converts warnings to errors in Dockerfiles to prevent this from occurring in the future.