### PR TITLE
Add commit date to version information

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() {
         get_long_version(&commit, &commit_date)
     );
     println!("cargo:rustc-env=AUDIOSERVE_COMMIT={}", commit);
+    println!("cargo:rustc-env=AUDIOSERVE_COMMIT_WITH_DATE={} ({})", commit, commit_date);
     println!("cargo:rustc-env=AUDIOSERVE_FEATURES={}", get_features());
 }
 

--- a/build.rs
+++ b/build.rs
@@ -2,17 +2,18 @@ use std::{env, process::Command};
 
 fn main() {
     let commit = get_commit();
+    let commit_date = get_commit_date();
     println!(
         "cargo:rustc-env=AUDIOSERVE_LONG_VERSION={}",
-        get_long_version(&commit)
+        get_long_version(&commit, &commit_date)
     );
     println!("cargo:rustc-env=AUDIOSERVE_COMMIT={}", commit);
     println!("cargo:rustc-env=AUDIOSERVE_FEATURES={}", get_features());
 }
 
-fn get_long_version(commit: &str) -> String {
+fn get_long_version(commit: &str, commit_date: &str) -> String {
     let ver = env::var("CARGO_PKG_VERSION").expect("cargo version is missing");
-    format!("{} #{}", ver, commit)
+    format!("{} #{} ({})", ver, commit, commit_date)
 }
 
 const FEATURE_PREFIX: &str = "CARGO_FEATURE_";
@@ -31,6 +32,23 @@ fn get_commit() -> String {
         .output()
         .map(|mut o| {
             o.stdout.truncate(7);
+            String::from_utf8(o.stdout).expect("git output must be utf-8")
+        })
+        .unwrap_or_else(|e| {
+            eprintln!("Error running git: {}", e);
+            "?".to_string()
+        })
+}
+
+fn get_commit_date() -> String {
+    Command::new("git")
+        .args(["log", "-1", "--format=%cd", "--date=format:%d.%m.%Y %H:%M:%S", "HEAD"])
+        .output()
+        .map(|mut o| {
+            // trim trailing newline
+            while o.stdout.last() == Some(&b'\n') || o.stdout.last() == Some(&b'\r') {
+                o.stdout.pop();
+            }
             String::from_utf8(o.stdout).expect("git output must be utf-8")
         })
         .unwrap_or_else(|e| {

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,10 @@ fn main() {
         get_long_version(&commit, &commit_date)
     );
     println!("cargo:rustc-env=AUDIOSERVE_COMMIT={}", commit);
-    println!("cargo:rustc-env=AUDIOSERVE_COMMIT_WITH_DATE={} ({})", commit, commit_date);
+    println!(
+        "cargo:rustc-env=AUDIOSERVE_COMMIT_WITH_DATE={} ({})",
+        commit, commit_date
+    );
     println!("cargo:rustc-env=AUDIOSERVE_FEATURES={}", get_features());
 }
 
@@ -43,7 +46,13 @@ fn get_commit() -> String {
 
 fn get_commit_date() -> String {
     Command::new("git")
-        .args(["log", "-1", "--format=%cd", "--date=format:%d.%m.%Y %H:%M:%S", "HEAD"])
+        .args([
+            "log",
+            "-1",
+            "--format=%cd",
+            "--date=format:%d.%m.%Y %H:%M:%S",
+            "HEAD",
+        ])
         .output()
         .map(|mut o| {
             // trim trailing newline

--- a/src/services/api.rs
+++ b/src/services/api.rs
@@ -38,7 +38,7 @@ const UNKNOWN_NAME: &str = "unknown";
 pub fn collections_list(compress: bool) -> ResponseResult {
     let collections = CollectionsInfo {
         version: env!("CARGO_PKG_VERSION"),
-        commit: env!("AUDIOSERVE_COMMIT"),
+        commit: env!("AUDIOSERVE_COMMIT_WITH_DATE"),
         folder_download: !get_config().disable_folder_download,
         shared_positions: cfg!(feature = "shared-positions"),
         count: get_config().base_dirs.len() as u32,


### PR DESCRIPTION
## Summary
This PR enhances the version information displayed by audioserve to include the commit date alongside the commit hash. This provides users with better context about when a particular build was created.

## Key Changes
- **build.rs**: 
  - Added `get_commit_date()` function that retrieves the commit date using `git log` with format `%d.%m.%Y %H:%M:%S`
  - Updated `get_long_version()` to accept and include commit date in the version string format
  - Added new environment variable `AUDIOSERVE_COMMIT_WITH_DATE` that combines commit hash and date
  - Modified version string format from `{version} #{commit}` to `{version} #{commit} ({date})`

- **src/services/api.rs**:
  - Updated `collections_list()` to use the new `AUDIOSERVE_COMMIT_WITH_DATE` environment variable instead of just `AUDIOSERVE_COMMIT`

## Implementation Details
- The commit date is retrieved using `git log -1 --format=%cd --date=format:%d.%m.%Y %H:%M:%S HEAD`
- The implementation properly handles trailing newlines/carriage returns from git output
- Graceful fallback to "?" if git command fails, consistent with existing error handling
- The date format is human-readable (DD.MM.YYYY HH:MM:SS)

https://claude.ai/code/session_01DZr4681ahSqDaTAnomkw7B